### PR TITLE
add functionality for managing fabric ethernet lan ports

### DIFF
--- a/tests/unit_test/network/test_ut_network_fabriceth.py
+++ b/tests/unit_test/network/test_ut_network_fabriceth.py
@@ -1,0 +1,172 @@
+import pytest
+from ucsm_apis.network import fabriceth
+from ucsmsdk.ucshandle import UcsHandle
+
+handle = UcsHandle("10.10.10.10", "username", "password")
+
+
+def test_fabric_eth_enable_success(mocker):
+    mock_login = mocker.patch('ucsmsdk.ucshandle.UcsHandle.login',
+                              autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch('ucsmsdk.ucshandle.UcsHandle.query_dn',
+                                 autospec=True)
+    mock_query_dn.return_value = "fabric/lan/A"
+    mock_commit = mocker.patch('ucsmsdk.ucshandle.UcsHandle.commit',
+                               autospec=True)
+    mock_commit.return_value = None
+    mock_fabric_eth = mocker.patch('ucsm_apis.network.'
+                                   'fabriceth.FabricEthLanEp')
+    mock_add_mo = mocker.patch('ucsmsdk.ucshandle.UcsHandle.add_mo',
+                               autospec=True)
+    mock_add_mo.return_value = None
+
+    fabriceth.fabric_eth_enable(handle, fabric="A",
+                                slot_id="1", port_id="1")
+
+    mock_query_dn.assert_called_with(handle, "fabric/lan/A")
+    mock_fabric_eth.assert_called_with(admin_state="enabled", slot_id="1",
+                                       port_id="1", admin_speed="10gbps",
+                                       parent_mo_or_dn="fabric/lan/A")
+
+
+def test_fabric_eth_enable_fail_org_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(fabriceth.UcsOperationError):
+        fabriceth.fabric_eth_enable(handle, fabric="A",
+                                    slot_id="1", port_id="100")
+
+
+def test_fabric_eth_get_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "fabric/lan/A/phys-slot-1-port-1"
+
+    fabriceth.fabric_eth_get(handle, fabric="A",
+                             slot_id="1", port_id="1")
+
+    mock_query_dn.assert_called_with(handle, "fabric/lan/A/phys-slot-1-port-1")
+
+
+def test_fabric_eth_get_fail_port_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(fabriceth.UcsOperationError):
+        fabriceth.fabric_eth_get(handle, fabric="A",
+                                 slot_id="1", port_id="100")
+
+
+def test_fabric_eth_exists_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "fabric/lan/A/phys-slot-1-port-1"
+    mock_check_prop = mocker.patch.object(fabriceth.FabricEthLanEp,
+                                          'check_prop_match', autospec=True)
+    mock_check_prop.return_value = True
+    mock_get = mocker.patch.object(fabriceth, 'fabric_eth_get', autospec=True)
+
+    fabriceth.fabric_eth_exists(handle, fabric="A",
+                                slot_id="1", port_id="1")
+
+    mock_get.assert_called_with(handle=handle, caller='fabric_eth_exists',
+                                fabric="A", slot_id="1", port_id="1")
+
+
+def test_fabric_eth_exists_fail_org_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(fabriceth, 'fabric_eth_get', autospec=True)
+    mock_get.side_effect = fabriceth.UcsOperationError("query_dn",
+                                                    "port does not exist")
+
+    result = fabriceth.fabric_eth_exists(handle, fabric="A",
+                                         slot_id="1", port_id="100")
+
+    assert result == (False, None)
+
+
+def test_fabric_eth_modify_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(fabriceth, 'fabric_eth_get', autospec=True)
+    mo_mock = mocker.Mock()
+    mo_mock.set_prop_multiple.return_value = True
+    mock_get.return_value = mo_mock
+    mock_set_mo = mocker.patch.object(UcsHandle, 'set_mo', autospec=True)
+    mock_set_mo.return_value = None
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    fabriceth.fabric_eth_modify(handle, fabric="A",
+                          slot_id="1",
+                          port_id="2",
+                          usr_lbl="test")
+
+    mock_get.assert_called_with(handle=handle, fabric="A",
+                                slot_id="1", port_id="2",
+                                caller="fabric_eth_modify")
+    mo_mock.set_prop_multiple.assert_called_with(usr_lbl="test")
+
+
+def test_fabric_eth_modify_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(fabriceth, 'fabric_eth_get', autospec=True)
+    mock_get.side_effect = fabriceth.UcsOperationError("query_dn",
+                                                    "port does not exist")
+
+    with pytest.raises(fabriceth.UcsOperationError):
+        fabriceth.fabric_eth_modify(handle, fabric="A",
+                                    slot_id="1", port_id="100",
+                                    usr_lbl="no aqui")
+
+
+def test_fabric_eth_disable_success(mocker):
+    mock_login = mocker.patch('ucsmsdk.ucshandle.UcsHandle.login',
+                              autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch('ucsmsdk.ucshandle.UcsHandle.query_dn',
+                                 autospec=True)
+    mock_query_dn.return_value = "fabric/lan/A"
+    mock_commit = mocker.patch('ucsmsdk.ucshandle.'
+                               'UcsHandle.commit',
+                               autospec=True)
+    mock_commit.return_value = None
+    mock_fabric_eth = mocker.patch('ucsm_apis.network.'
+                                   'fabriceth.FabricEthLanEp')
+    mock_add_mo = mocker.patch('ucsmsdk.ucshandle.UcsHandle.add_mo',
+                               autospec=True)
+    mock_add_mo.return_value = None
+
+    fabriceth.fabric_eth_disable(handle, fabric="A",
+                                slot_id="1", port_id="1")
+
+    mock_query_dn.assert_called_with(handle, "fabric/lan/A")
+    mock_fabric_eth.assert_called_with(admin_state="disabled", slot_id="1",
+                                       port_id="1",
+                                       parent_mo_or_dn="fabric/lan/A")
+
+
+def test_fabric_eth_disable_failure_org_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(fabriceth.UcsOperationError):
+        fabriceth.fabric_eth_disable(handle, fabric="A",
+                                    slot_id="1", port_id="100")

--- a/ucsm_apis/network/fabriceth.py
+++ b/ucsm_apis/network/fabriceth.py
@@ -1,0 +1,217 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs operations related to Fabric Ethernet Lan Ports.
+"""
+
+from ucsmsdk.mometa.fabric.FabricEthLanEp import FabricEthLanEp
+from ucsmsdk.ucsexception import UcsOperationError
+
+
+def fabric_eth_enable(handle, fabric=None,
+                      slot_id=None, port_id=None,
+                      **kwargs):
+
+    """
+    Enables fabric ethernet lan port
+
+    Args:
+        handle (UCSHandle)
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        FabricEthLanEp: managed object
+
+    Raises:
+        UcsOperationError: if Org_dn is not present
+
+    Example:
+        fabric_eth_enable(handle,
+                           fabric="A",
+                           slot_id="1",
+                           port_id="2")
+    """
+
+    org_dn = "fabric/lan/" + fabric
+    obj = handle.query_dn(org_dn)
+    if not obj:
+        raise UcsOperationError("fabric_eth_enable", "Org {} \
+                                 does not exist".format(org_dn))
+
+    mo = FabricEthLanEp(parent_mo_or_dn=obj, admin_state="enabled",
+                        port_id=port_id, slot_id=slot_id,
+                        admin_speed="10gbps")
+    mo.set_prop_multiple(**kwargs)
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def fabric_eth_get(handle, fabric=None,
+                   slot_id=None, port_id=None,
+                   caller="fabric_eth_get"):
+
+    """
+    Gets fabric ethernet lan port
+
+    Args:
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        caller (string): caller method name
+
+    Returns:
+        FabricEthLanEp: managed object
+
+    Raises:
+        UcsOperationError: if FabricEthLanEp is not present
+
+    Example:
+        fabric_eth_get(handle,
+                        fabric="A",
+                        slot_id="1",
+                        port_id="2")
+    """
+
+    dn = "fabric/lan/" + fabric + "/phys-slot-" + slot_id + "-port-" + port_id
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise UcsOperationError(caller, "Fabric port {} \
+                                does not exist".format(dn))
+    return mo
+
+
+def fabric_eth_exists(handle, fabric=None, slot_id=None,
+                   port_id=None, **kwargs):
+
+    """
+    checks if fabric ethernel lan port exists
+
+    Args:
+        handle (UCSHandle)
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, FabricEthLanEp MO/None)
+
+    Raises:
+        None
+
+    Example:
+        fabric_eth_exists:(handle,
+                           fabric="A",
+                           slot_id="1",
+                           port_id="2")
+    """
+
+    try:
+        mo = fabric_eth_get(handle=handle, fabric=fabric,
+                            slot_id=slot_id,
+                            port_id=port_id,
+                            caller="fabric_eth_exists")
+    except UcsOperationError:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def fabric_eth_modify(handle, fabric=None, slot_id=None,
+                      port_id=None, **kwargs):
+
+    """
+    modifies ip pool
+
+    Args:
+        handle (UCSHandle)
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        FabricEthLanEp: managed object
+
+    Raises:
+        UcsOperationError: if FabricEthLanEp is not present
+
+    Example:
+        fabric_eth_modify(handle,
+                          fabric="A",
+                          slot_id="1",
+                          port_id="2")
+    """
+
+    mo = fabric_eth_get(handle=handle, fabric=fabric,
+                        slot_id=slot_id,
+                        port_id=port_id,
+                        caller="fabric_eth_modify")
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def fabric_eth_disable(handle, fabric=None,
+                       slot_id=None, port_id=None,
+                       **kwargs):
+
+    """
+    Disables fabric ethernet lan port
+
+    Args:
+        handle (UCSHandle)
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        None
+
+    Raises:
+        UcsOperationError: if if FabricEthLanEp is not present
+
+    Example:
+        fabric_eth_disable(handle,
+                          fabric="A",
+                          slot_id="1",
+                          port_id="2")
+    """
+
+    org_dn = "fabric/lan/" + fabric
+    obj = handle.query_dn(org_dn)
+    if not obj:
+        raise UcsOperationError("fabric_eth_enable", "Org {} \
+                                 does not exist".format(org_dn))
+
+    mo = FabricEthLanEp(parent_mo_or_dn=obj, admin_state="disabled",
+                        port_id=port_id, slot_id=slot_id)
+    mo.set_prop_multiple(**kwargs)
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo


### PR DESCRIPTION
complete fabriceth.py and test_ut_network_fabriceth.py
flake8 fixes

This feature makes enabling/disabling and modifying fabric ethernet uplink ports in UCS easier. The modules defined here are the equivalent of selecting a fabric ethernet port in the UCSM GUI and configuring as a uplink port or deconfiguring. The unit tests were written using pytest.