### PR TITLE
add functionality to configure/deconfigure fabric server ports

### DIFF
--- a/tests/unit_test/network/test_ut_network_fabricsvr.py
+++ b/tests/unit_test/network/test_ut_network_fabricsvr.py
@@ -1,0 +1,171 @@
+import pytest
+from ucsm_apis.network import fabricsvr
+from ucsmsdk.ucshandle import UcsHandle
+
+handle = UcsHandle("10.10.10.10", "username", "password")
+
+
+def test_fabric_svr_enable_success(mocker):
+    mock_login = mocker.patch('ucsmsdk.ucshandle.UcsHandle.login',
+                              autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch('ucsmsdk.ucshandle.UcsHandle.query_dn',
+                                 autospec=True)
+    mock_query_dn.return_value = "fabric/server/sw-A"
+    mock_commit = mocker.patch('ucsmsdk.ucshandle.UcsHandle.commit',
+                               autospec=True)
+    mock_commit.return_value = None
+    mock_fabric_svr = mocker.patch('ucsm_apis.network.'
+                                   'fabricsvr.FabricDceSwSrvEp')
+    mock_add_mo = mocker.patch('ucsmsdk.ucshandle.UcsHandle.add_mo',
+                               autospec=True)
+    mock_add_mo.return_value = None
+
+    fabricsvr.fabric_svr_enable(handle, fabric="A",
+                                slot_id="1", port_id="1")
+
+    mock_query_dn.assert_called_with(handle, "fabric/server/sw-A")
+    mock_fabric_svr.assert_called_with(admin_state="enabled", slot_id="1",
+                                       port_id="1",
+                                       parent_mo_or_dn="fabric/server/sw-A")
+
+
+def test_fabric_svr_enable_fail_org_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(fabricsvr.UcsOperationError):
+        fabricsvr.fabric_svr_enable(handle, fabric="A",
+                                    slot_id="1", port_id="100")
+
+
+def test_fabric_svr_get_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "fabric/server/sw-A/slot-1-port-1"
+
+    fabricsvr.fabric_svr_get(handle, fabric="A",
+                             slot_id="1", port_id="1")
+
+    mock_query_dn.assert_called_with(handle, "fabric/server/"
+                                             "sw-A/slot-1-port-1")
+
+
+def test_fabric_svr_get_fail_port_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(fabricsvr.UcsOperationError):
+        fabricsvr.fabric_svr_get(handle, fabric="A",
+                                 slot_id="1", port_id="100")
+
+
+def test_fabric_svr_exists_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "fabric/server/sw-A/slot-1-port-1"
+    mock_check_prop = mocker.patch.object(fabricsvr.FabricDceSwSrvEp,
+                                          'check_prop_match', autospec=True)
+    mock_check_prop.return_value = True
+    mock_get = mocker.patch.object(fabricsvr, 'fabric_svr_get', autospec=True)
+
+    fabricsvr.fabric_svr_exists(handle, fabric="A",
+                                slot_id="1", port_id="1")
+
+    mock_get.assert_called_with(handle=handle, caller='fabric_svr_exists',
+                                fabric="A", slot_id="1", port_id="1")
+
+
+def test_fabric_svr_exists_fail_org_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(fabricsvr, 'fabric_svr_get', autospec=True)
+    mock_get.side_effect = fabricsvr.UcsOperationError("query_dn",
+                                                    "port does not exist")
+
+    result = fabricsvr.fabric_svr_exists(handle, fabric="A",
+                                         slot_id="1", port_id="100")
+
+    assert result == (False, None)
+
+
+def test_fabric_svr_modify_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(fabricsvr, 'fabric_svr_get', autospec=True)
+    mo_mock = mocker.Mock()
+    mo_mock.set_prop_multiple.return_value = True
+    mock_get.return_value = mo_mock
+    mock_set_mo = mocker.patch.object(UcsHandle, 'set_mo', autospec=True)
+    mock_set_mo.return_value = None
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    fabricsvr.fabric_svr_modify(handle, fabric="A",
+                          slot_id="1",
+                          port_id="2",
+                          usr_lbl="test")
+
+    mock_get.assert_called_with(handle=handle, fabric="A",
+                                slot_id="1", port_id="2",
+                                caller="fabric_svr_modify")
+    mo_mock.set_prop_multiple.assert_called_with(usr_lbl="test")
+
+
+def test_fabric_svr_modify_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(fabricsvr, 'fabric_svr_get', autospec=True)
+    mock_get.side_effect = fabricsvr.UcsOperationError("query_dn",
+                                                    "port does not exist")
+
+    with pytest.raises(fabricsvr.UcsOperationError):
+        fabricsvr.fabric_svr_modify(handle, fabric="A",
+                                    slot_id="1", port_id="100",
+                                    usr_lbl="no aqui")
+
+
+def test_fabric_svr_disable_success(mocker):
+    mock_login = mocker.patch('ucsmsdk.ucshandle.UcsHandle.login',
+                              autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch('ucsmsdk.ucshandle.UcsHandle.query_dn',
+                                 autospec=True)
+    mock_query_dn.return_value = "fabric/server/sw-A/slot-1-port-1"
+    mock_commit = mocker.patch('ucsmsdk.ucshandle.'
+                               'UcsHandle.commit',
+                               autospec=True)
+    mock_commit.return_value = None
+    mock_remove_mo = mocker.patch('ucsmsdk.ucshandle.UcsHandle.remove_mo',
+                               autospec=True)
+    mock_remove_mo.return_value = None
+
+    fabricsvr.fabric_svr_disable(handle, fabric="A",
+                                slot_id="1", port_id="1")
+
+    mock_query_dn.assert_called_with(handle, "fabric/server/"
+                                             "sw-A/slot-1-port-1")
+    assert mock_remove_mo.call_count == 1
+    assert mock_commit.call_count == 1
+
+
+def test_fabric_svr_disable_failure_org_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(fabricsvr.UcsOperationError):
+        fabricsvr.fabric_svr_disable(handle, fabric="A",
+                                    slot_id="1", port_id="100")

--- a/ucsm_apis/network/fabricsvr.py
+++ b/ucsm_apis/network/fabricsvr.py
@@ -1,0 +1,213 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs operations related to Fabric Ethernet Lan Ports.
+"""
+
+from ucsmsdk.mometa.fabric.FabricDceSwSrvEp import FabricDceSwSrvEp
+from ucsmsdk.ucsexception import UcsOperationError
+
+
+def fabric_svr_enable(handle, fabric=None,
+                      slot_id=None, port_id=None,
+                      **kwargs):
+
+    """
+    Enables fabric server port
+
+    Args:
+        handle (UCSHandle)
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        FabricDceSwSrvEp: managed object
+
+    Raises:
+        UcsOperationError: if Org_dn is not present
+
+    Example:
+        fabric_eth_enable(handle,
+                           fabric="A",
+                           slot_id="1",
+                           port_id="2")
+    """
+
+    org_dn = "fabric/server/sw-" + fabric
+    obj = handle.query_dn(org_dn)
+    if not obj:
+        raise UcsOperationError("fabric_svr_enable", "Org {} \
+                                 does not exist".format(org_dn))
+
+    mo = FabricDceSwSrvEp(parent_mo_or_dn=obj, admin_state="enabled",
+                        port_id=port_id, slot_id=slot_id)
+    mo.set_prop_multiple(**kwargs)
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def fabric_svr_get(handle, fabric=None,
+                   slot_id=None, port_id=None,
+                   caller="fabric_svr_get"):
+
+    """
+    Gets fabric ethernet server port
+
+    Args:
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        caller (string): caller method name
+
+    Returns:
+        FabricDceSwSrvEp: managed object
+
+    Raises:
+        UcsOperationError: if FabricDceSwSrvEp is not present
+
+    Example:
+        fabric_svr_get(handle,
+                        fabric="A",
+                        slot_id="1",
+                        port_id="2")
+    """
+
+    dn = "fabric/server/sw-" + fabric + "/slot-" + slot_id + "-port-" + port_id
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise UcsOperationError(caller, "Fabric port {} \
+                                does not exist".format(dn))
+    return mo
+
+
+def fabric_svr_exists(handle, fabric=None, slot_id=None,
+                   port_id=None, **kwargs):
+
+    """
+    checks if fabric server port exists
+
+    Args:
+        handle (UCSHandle)
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, FabricDceSwSrvEp MO/None)
+
+    Raises:
+        None
+
+    Example:
+        fabric_svr_exists:(handle,
+                           fabric="A",
+                           slot_id="1",
+                           port_id="2")
+    """
+
+    try:
+        mo = fabric_svr_get(handle=handle, fabric=fabric,
+                            slot_id=slot_id,
+                            port_id=port_id,
+                            caller="fabric_svr_exists")
+    except UcsOperationError:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def fabric_svr_modify(handle, fabric=None, slot_id=None,
+                      port_id=None, **kwargs):
+
+    """
+    modifies fabric server port
+
+    Args:
+        handle (UCSHandle)
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        FabricDceSwSrvEp: managed object
+
+    Raises:
+        UcsOperationError: if FabricDceSwSrvEp is not present
+
+    Example:
+        fabric_svr_modify(handle,
+                          fabric="A",
+                          slot_id="1",
+                          port_id="2")
+    """
+
+    mo = fabric_svr_get(handle=handle, fabric=fabric,
+                        slot_id=slot_id,
+                        port_id=port_id,
+                        caller="fabric_svr_modify")
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def fabric_svr_disable(handle, fabric=None,
+                       slot_id=None, port_id=None,
+                       **kwargs):
+
+    """
+    Disables fabric server port
+
+    Args:
+        handle (UCSHandle)
+        fabric (string): Fabric A or B
+        slot_id (string): Fabric slot number
+        port_id (string): port number
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        None
+
+    Raises:
+        UcsOperationError: if if FabricDceSwSrvEp is not present
+
+    Example:
+        fabric_svr_disable(handle,
+                          fabric="A",
+                          slot_id="1",
+                          port_id="2")
+    """
+
+    dn = "fabric/server/sw-" + fabric + "/slot-" + slot_id + "-port-" + port_id
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise UcsOperationError("fabric_svr_disable", "Org {} \
+                                 does not exist".format(dn))
+
+    handle.remove_mo(mo)
+    handle.commit()
+    return mo


### PR DESCRIPTION
This module adds the ability to configure and deconfigure Fabric ports as Server ports. This functionality is equivalent to right-clicking a fabric ethernet port in the UCSM GUI and selecting "Configure as Server Port" which tells UCS that the port in question is connected to a C-Series server. All unit tests for this module were written with pytest.