### PR TITLE
add functionality to manage mac pools

### DIFF
--- a/tests/unit_test/network/test_ut_network_macpool.py
+++ b/tests/unit_test/network/test_ut_network_macpool.py
@@ -1,0 +1,327 @@
+import pytest
+from ucsm_apis.network import macpool
+from ucsmsdk.ucshandle import UcsHandle
+
+handle = UcsHandle("10.10.10.10", "username", "password")
+
+
+def test_mac_pool_create_success(mocker):
+    mock_login = mocker.patch('ucsmsdk.ucshandle.UcsHandle.login',
+                              autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch('ucsmsdk.ucshandle.UcsHandle.query_dn',
+                                 autospec=True)
+    mock_query_dn.return_value = "org-root"
+    mock_commit = mocker.patch('ucsmsdk.ucshandle.UcsHandle.commit',
+                               autospec=True)
+    mock_commit.return_value = None
+    mock_mac_pool = mocker.patch('ucsm_apis.network.macpool.MacpoolPool')
+    mock_add_mo = mocker.patch('ucsmsdk.ucshandle.UcsHandle.add_mo',
+                               autospec=True)
+    mock_add_mo.return_value = None
+
+    macpool.mac_pool_create(handle, name="dummypool")
+
+    mock_query_dn.assert_called_with(handle, "org-root")
+    mock_mac_pool.assert_called_with(name='dummypool',
+                                     assignment_order="default",
+                                     descr=None,
+                                     parent_mo_or_dn='org-root')
+
+
+def test_mac_pool_create_fail_org_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(macpool.UcsOperationError):
+        macpool.mac_pool_create(handle, name="dummypool",
+                                org_dn="dummy")
+
+
+def test_mac_pool_get_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "org-root/mac-pool-dummypool"
+
+    macpool.mac_pool_get(handle, name="dummypool")
+
+    mock_query_dn.assert_called_with(handle, "org-root/mac-pool-dummypool")
+
+
+def test_mac_pool_get_fail_pool_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(macpool.UcsOperationError):
+        macpool.mac_pool_get(handle, "nopool")
+
+
+def test_mac_pool_exists_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "org-root/mac-pool-dummypool"
+    mock_check_prop = mocker.patch.object(macpool.MacpoolPool,
+                                          'check_prop_match', autospec=True)
+    mock_check_prop.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_pool_get', autospec=True)
+
+    macpool.mac_pool_exists(handle, name="dummypool")
+
+    mock_get.assert_called_with(handle=handle, caller='mac_pool_exists',
+                                name="dummypool", org_dn="org-root")
+
+
+def test_mac_pool_exists_fail_org_does_not_exist(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_pool_get', autospec=True)
+    mock_get.side_effect = macpool.UcsOperationError("query_dn",
+                                                    "pool does not exist")
+
+    result = macpool.mac_pool_exists(handle, name="dummypool")
+
+    assert result == (False, None)
+
+
+def test_mac_pool_modify_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_pool_get', autospec=True)
+    mo_mock = mocker.Mock()
+    mo_mock.set_prop_multiple.return_value = True
+    mock_get.return_value = mo_mock
+    mock_set_mo = mocker.patch.object(UcsHandle, 'set_mo', autospec=True)
+    mock_set_mo.return_value = None
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    macpool.mac_pool_modify(handle, name="dummypool",
+                            descr="This is a new pool")
+
+    mock_get.assert_called_with(handle=handle, name="dummypool",
+                                org_dn="org-root", caller="mac_pool_modify")
+    mo_mock.set_prop_multiple.assert_called_with(descr="This is a new pool")
+
+
+def test_mac_pool_modify_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_pool_get', autospec=True)
+    mock_get.side_effect = macpool.UcsOperationError("query_dn",
+                                                    "pool does not exist")
+
+    with pytest.raises(macpool.UcsOperationError):
+        macpool.mac_pool_modify(handle, name="nopool", descr="Pool no aqui")
+
+
+def test_mac_pool_delete_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_pool_get', autospec=True)
+    mock_remove_mo = mocker.patch.object(UcsHandle, 'remove_mo',
+                                         autospec=True)
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    macpool.mac_pool_delete(handle, "dummypool")
+
+    mock_get.assert_called_with(handle=handle, name="dummypool",
+                                org_dn="org-root", caller="mac_pool_delete")
+    assert mock_remove_mo.call_count == 1
+
+
+def test_mac_pool_delete_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_pool_get', autospec=True)
+    mock_get.side_effect = macpool.UcsOperationError("query_dn",
+                                                    "pool does not exist")
+
+    with pytest.raises(macpool.UcsOperationError):
+        macpool.mac_pool_delete(handle, "dummypool")
+
+
+def test_mac_block_create_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn',
+                                        autospec=True)
+    mock_query_dn.return_value = "org-root/mac-pool-dummypool"
+    mock_mac_pool_block = mocker.patch.object(macpool, 'MacpoolBlock',
+                                             autospec=True)
+    mock_add_mo = mocker.patch.object(UcsHandle, 'add_mo', autospec=True)
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+
+    macpool.mac_block_create(handle, pool_name="dummypool",
+                             start_mac="00:25:B5:00:0A:00",
+                             end_mac="00:25:B5:00:0A:3F")
+
+    assert mock_query_dn.call_count == 2
+    mock_mac_pool_block.assert_called_with(parent_mo_or_dn="org-root/"
+                                           "mac-pool-dummypool",
+                                           r_from="00:25:B5:00:0A:00",
+                                           to="00:25:B5:00:0A:3F")
+    mock_add_mo.assert_called()
+    mock_commit.assert_called()
+
+
+def test_mac_block_create_fail_org_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn', autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(macpool.UcsOperationError):
+        macpool.mac_block_create(handle, pool_name="dummypool",
+                                 start_mac="00:25:B5:00:0A:00",
+                                 end_mac="00:25:B5:00:0A:3F")
+
+
+def test_mac_block_get_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn', autospec=True)
+
+    macpool.mac_block_get(handle, pool_name="dummypool",
+                          start_mac="00:25:B5:00:0A:00",
+                          end_mac="00:25:B5:00:0A:3F")
+
+    mock_query_dn.assert_called_with(handle,
+                                     "org-root/"
+                                     "mac-pool-dummypool/"
+                                     "block-00:25:B5:00:0A"
+                                     ":00-00:25:B5:00:0A:3F")
+
+
+def test_mac_block_get_fail_block_non_existent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn', autospec=True)
+    mock_query_dn.return_value = None
+
+    with pytest.raises(macpool.UcsOperationError):
+        macpool.mac_block_get(handle, pool_name="dummypool",
+                              start_mac="00:25:B5:00:0A:00",
+                              end_mac="00:25:B5:00:0A:3F")
+
+
+def test_mac_block_exists_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_query_dn = mocker.patch.object(UcsHandle, 'query_dn', autospec=True)
+    mock_query_dn.return_value = "org-root/mac-pool-dummypool"
+    managed_object_mock = mocker.Mock()
+    managed_object_mock.check_prop_match.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_block_get', autospec=True)
+    mock_get.return_value = managed_object_mock
+
+    result = macpool.mac_block_exists(handle, pool_name="dummypool",
+                                      start_mac="00:25:B5:00:0A:00",
+                                      end_mac="00:25:B5:00:0A:3F")
+
+    mock_get.assert_called_with(handle=handle, caller='mac_block_exists',
+                                pool_name="dummypool", org_dn="org-root",
+                                start_mac="00:25:B5:00:0A:00",
+                                end_mac="00:25:B5:00:0A:3F")
+    managed_object_mock.check_prop_match.assert_called()
+    assert result == (True, managed_object_mock)
+
+
+def test_mac_block_exists_fail(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_block_get', autospec=True)
+    mock_get.side_effect = macpool.UcsOperationError("query_dn",
+                                                    "block does not exist")
+
+    result = macpool.mac_block_exists(handle, pool_name="dummypool",
+                                      start_mac="00:25:B5:00:0A:00",
+                                      end_mac="00:25:B5:00:0A:3F")
+
+    assert result == (False, None)
+
+
+def test_mac_block_modify_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_block_get', autospec=True)
+    mo_mock = mocker.Mock()
+    mo_mock.set_prop_multiple.return_value = True
+    mock_get.return_value = mo_mock
+    mock_set_mo = mocker.patch.object(UcsHandle, 'set_mo', autospec=True)
+    mock_set_mo.return_value = None
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    macpool.mac_block_modify(handle,
+                             pool_name="dummypool",
+                             org_dn="org-root",
+                             start_mac="00:25:B5:00:0A:00",
+                             end_mac="00:25:B5:00:0A:3F",
+                             status="modified")
+
+    mock_get.assert_called_with(handle=handle, pool_name="dummypool",
+                                org_dn="org-root",
+                                caller="mac_block_modify",
+                                start_mac="00:25:B5:00:0A:00",
+                                end_mac="00:25:B5:00:0A:3F")
+    mo_mock.set_prop_multiple.assert_called_with(status="modified")
+
+
+def test_mac_block_modify_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_block_get', autospec=True)
+    mock_get.side_effect = macpool.UcsOperationError("query_dn",
+                                                    "pool does not exist")
+
+    with pytest.raises(macpool.UcsOperationError):
+        macpool.mac_block_modify(handle,
+                             pool_name="nopool",
+                             org_dn="org-root",
+                             start_mac="00:25:B5:00:0A:00",
+                             end_mac="00:25:B5:00:0A:3F",
+                             status="modified")
+
+
+def test_mac_block_delete_success(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_block_get', autospec=True)
+    mock_remove_mo = mocker.patch.object(UcsHandle, 'remove_mo', autospec=True)
+    mock_commit = mocker.patch.object(UcsHandle, 'commit', autospec=True)
+    mock_commit.return_value = None
+
+    macpool.mac_block_delete(handle, pool_name="dummypool",
+                             start_mac="00:25:B5:00:0A:00",
+                             end_mac="00:25:B5:00:0A:3F")
+
+    mock_get.assert_called_with(handle=handle, pool_name="dummypool",
+                                org_dn="org-root",
+                                start_mac="00:25:B5:00:0A:00",
+                                end_mac="00:25:B5:00:0A:3F",
+                                caller="mac_block_delete")
+    assert mock_remove_mo.call_count == 1
+
+
+def test_mac_blcok_delete_failure_pool_nonexistent(mocker):
+    mock_login = mocker.patch.object(UcsHandle, 'login', autospec=True)
+    mock_login.return_value = True
+    mock_get = mocker.patch.object(macpool, 'mac_block_get', autospec=True)
+    mock_get.side_effect = macpool.UcsOperationError("query_dn",
+                                                    "block does not exist")
+
+    with pytest.raises(macpool.UcsOperationError):
+        macpool.mac_block_delete(handle, pool_name="dummypool",
+                                 start_mac="00:25:B5:00:0A:00",
+                                 end_mac="00:25:B5:00:0A:00")

--- a/ucsm_apis/network/macpool.py
+++ b/ucsm_apis/network/macpool.py
@@ -1,0 +1,398 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs operations related to mac pools.
+"""
+
+from ucsmsdk.mometa.macpool.MacpoolPool import MacpoolPool
+from ucsmsdk.mometa.macpool.MacpoolBlock import MacpoolBlock
+from ucsmsdk.ucsexception import UcsOperationError
+
+
+def mac_pool_create(handle, org_dn="org-root",
+                    name=None,
+                    assign="default",
+                    descr=None, **kwargs):
+
+    """
+    Creates mac pool
+
+    Args:
+        handle (UCSHandle)
+        name (string): Name of mac pool
+        org_dn (string): org dn
+        assign (string): Assignment order (default or sequential)
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        MacpoolPool: managed object
+
+    Raises:
+        UcsOperationError: if Org_dn is not present
+
+    Example:
+        mac_pool_create(handle,
+                        name="server_pool",
+                        org_dn="org-root",
+                        descr="Mac Pool for Servers")
+    """
+
+    obj = handle.query_dn(org_dn)
+    if not obj:
+        raise UcsOperationError("mac_pool_create", "Org {} \
+                                 does not exist".format(org_dn))
+
+    mo = MacpoolPool(parent_mo_or_dn=obj, name=name,
+                     assignment_order=assign,
+                     descr=descr)
+    mo.set_prop_multiple(**kwargs)
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def mac_pool_get(handle, name=None,
+                 org_dn="org-root",
+                 caller="mac_pool_get"):
+
+    """
+    Gets mac pool
+
+    Args:
+        handle (UCSHandle)
+        name (string): Name of mac pool
+        org_dn (string): org dn
+        caller (string): caller method name
+
+    Returns:
+        MacpoolPool: managed object
+
+    Raises:
+        UcsOperationError: if MacpoolPool is not present
+
+    Example:
+        mac_pool_get(handle,
+                     name="test_pool",
+                     org_dn="org-root")
+    """
+
+    dn = org_dn + "/mac-pool-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise UcsOperationError(caller, "Mac Pool {} \
+                                does not exist".format(dn))
+    return mo
+
+
+def mac_pool_exists(handle, name=None,
+                    org_dn="org-root", **kwargs):
+
+    """
+    checks if mac pool exists
+
+    Args:
+        handle (UcsHandle)
+        name (string): Name of mac pool
+        org_dn (string): org dn
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MacpoolPool MO/None)
+
+    Raises:
+        None
+
+    Example:
+        mac_pool_exists:(handle,
+                         name="mac_pool_A",
+                         org_dn="org-root",)
+    """
+
+    try:
+        mo = mac_pool_get(handle=handle, name=name, org_dn=org_dn,
+                         caller="mac_pool_exists")
+    except UcsOperationError:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def mac_pool_modify(handle, name=None,
+                    org_dn="org-root", **kwargs):
+
+    """
+    modifies mac pool
+
+    Args:
+        handle (UcsHandle)
+        name (string): Name of mac pool
+        org_dn (string): org dn
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        MacpoolPool: managed object
+
+    Raises:
+        UcsOperationError: if MacpoolPool is not present
+
+    Example:
+        mac_pool_modify(handle,
+                        name="test-pool",
+                        descr="prod mac pool")
+    """
+
+    mo = mac_pool_get(handle=handle, name=name, org_dn=org_dn,
+                      caller="mac_pool_modify")
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def mac_pool_delete(handle, name, org_dn="org-root"):
+
+    """
+    deletes mac pool
+
+    Args:
+        handle (UcsHandle)
+        name (string): Name of mac pool
+        org_dn (string): org dn
+
+    Returns:
+        None
+
+    Raises:
+        UcsOperationError: if MacpoolPool is not present
+
+    Example:
+        mac_pool_delete(handle,
+                        name="test-pool",
+                        org_dn="org-root")
+    """
+
+    mo = mac_pool_get(handle=handle, name=name, org_dn=org_dn,
+                      caller="mac_pool_delete")
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def mac_block_create(handle, pool_name=None, org_dn="org-root",
+                     start_mac=None, end_mac=None,
+                     **kwargs):
+
+    """
+    Creates block of mac addresses
+
+    Args:
+        handle (UCSHandle)
+        pool_name (string): Name of mac pool block is associated with
+        org_dn (string): org dn
+        start_mac (string): Starting mac address
+        end_mac (string): Ending mac address
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        MacpoolBlock: managed object
+
+    Raises:
+        UcsOperationError: if Org_dn is not present
+
+    Example:
+        mac_block_create(handle,
+                         pool_name="mac_pool_a",
+                         org_dn="org-root",
+                         start_mac="00:25:B5:00:0A:00",
+                         end_mac="00:25:B5:00:0A:3F",)
+    """
+
+    obj = handle.query_dn(org_dn)
+    dn = org_dn + "/mac-pool-" + pool_name
+    pool = handle.query_dn(dn)
+    if not obj:
+        raise UcsOperationError("mac_block_create", "Org {} \
+                                 does not exist".format(org_dn))
+    elif not pool:
+        raise UcsOperationError("mac_block_create", "Mac Pool {} \
+                                 does not exist".format(pool_name))
+
+    mo = MacpoolBlock(parent_mo_or_dn=dn, r_from=start_mac,
+                      to=end_mac)
+    mo.set_prop_multiple(**kwargs)
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def mac_block_get(handle, pool_name=None, org_dn="org-root",
+                  start_mac=None, end_mac=None, caller="mac_block_get"):
+
+    """
+    gets mac address block
+
+    Args:
+        handle (Ucshandle)
+        pool_name (string): Name of mac pool block is associated with
+        org_dn (string): org dn
+        start_mac (string): 1st ip in the block
+        end_mac (string): last ip in the block
+        caller (string): caller method name
+
+    Returns:
+        MacpoolBlock: managed object
+
+    Raises:
+        UcsOperationError: if MacpoolBlock is not present
+
+    Example:
+        mac_block_get(handle,
+                      pool_name="ext-mgmt",
+                      org_dn="org-root",
+                      start_mac="00:25:B5:00:0A:00",
+                      end_mac="00:25:B5:00:0A:3F")
+
+    """
+
+    dn = (org_dn + "/mac-pool-" +
+          pool_name + "/block-" +
+          start_mac + "-" + end_mac)
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise UcsOperationError(caller, "MAC Block {} \
+                                does not exist".format(dn))
+    return mo
+
+
+def mac_block_exists(handle, pool_name, org_dn="org-root", start_mac=None,
+                     end_mac=None, **kwargs):
+
+    """
+    checks if mac block exists
+
+    Args:
+        handle (UcsHandle)
+        pool_name (string): Name of mac pool block is associated with
+        org_dn (string): org dn
+        start_mac (string): 1st mac address in the block
+        end_mac (string): last mac address in the block
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MacpoolBlock MO/None)
+
+    Raises:
+        None
+
+    Example:
+        mac_block_exists:(handle,
+                          pool_name="default",
+                          org_dn="org-root",
+                          start_mac="00:25:B5:00:0A:00",
+                          end_mac="00:25:B5:00:0A:3F")
+
+    """
+
+    try:
+        mo = mac_block_get(handle=handle, pool_name=pool_name, org_dn=org_dn,
+                           start_mac=start_mac, end_mac=end_mac,
+                           caller="mac_block_exists")
+    except UcsOperationError:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def mac_block_modify(handle, pool_name, org_dn="org-root",
+                     start_mac=None, end_mac=None, **kwargs):
+
+    """
+    modifies mac block
+
+    Args:
+        handle (UcsHandle)
+        pool_name (string): Name of ip pool block is associated with
+        org_dn (string): org dn
+        start_mac (string): 1st mac address in the block
+        end_mac (string): last mac address in the block
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucscoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        MacpoolBlock: managed object
+
+    Raises:
+        UcsOperationError: if MacpoolBlock is not present
+
+    Example:
+        mac_block_modify(handle,
+                         pool_name="ext-mgmt",
+                         org_dn="org-root",
+                         start_mac="00:25:B5:00:0A:00",
+                         end_mac="00:25:B5:00:0A:3F",
+                         status="modified")
+    """
+
+    mo = mac_block_get(handle=handle, pool_name=pool_name, org_dn=org_dn,
+                       start_mac=start_mac, end_mac=end_mac,
+                       caller="mac_block_modify")
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def mac_block_delete(handle, pool_name=None, org_dn="org-root",
+                     start_mac=None, end_mac=None):
+
+    """
+    deletes mac block
+
+    Args:
+        handle (UcsHandle)
+        pool_name (string): Name of mac pool block is associated with
+        org_dn (string): org dn
+        start_mac (string): 1st mac address in the block
+        end_mac (string): last mac address in the block
+
+    Returns:
+        None
+
+    Raises:
+        UcsOperationError: if MacpoolBlock is not present
+
+    Example:
+        ip_block_delete(handle,
+                     pool_name="ext-mgmt",
+                     org_dn="org-root",
+                     start_mac="00:25:B5:00:0A:00",
+                     end_mac="00:25:B5:00:0A:3F")
+    """
+
+    mo = mac_block_get(handle=handle, pool_name=pool_name, org_dn=org_dn,
+                       start_mac=start_mac, end_mac=end_mac,
+                       caller="mac_block_delete")
+    handle.remove_mo(mo)
+    handle.commit()


### PR DESCRIPTION
This module adds functionality for managing mac address pools and mac address blocks in UCS. All unit tests were written with pytest.